### PR TITLE
Fix compiler errors for GCC 8.3

### DIFF
--- a/datastr/base/ttf_wrapper.h
+++ b/datastr/base/ttf_wrapper.h
@@ -299,7 +299,7 @@ public:
 
     std::pair<double,double> get_min_max() const noexcept
     {
-        if ( _is_constant ) return _constant_value;
+        if ( _is_constant ) return std::make_pair(_constant_value, _constant_value);
 
         assert( _ttf_impl_ptr );
         return std::make_pair(_ttf_impl_ptr->get_min(), _ttf_impl_ptr->get_max());

--- a/query/tch_ea_query.h
+++ b/query/tch_ea_query.h
@@ -43,6 +43,7 @@
 #include <stack>
 #include <tuple>
 #include <vector>
+#include <bitset>
 
 #include <boost/heap/pairing_heap.hpp>
 

--- a/util/misc.h
+++ b/util/misc.h
@@ -42,6 +42,7 @@
 #include <functional>
 #include <limits>
 #include <vector>
+#include <cmath>
 
 #include "datastr/graph/basic.h"
 


### PR DESCRIPTION
g++ 8.3 fails to compile this because a double is not a pair of doubles. Seems legit to me. expressionless

Also added two header includes which were missing for me to compile the query example.

Sorry the repost - had to switch my branch